### PR TITLE
Missing logging module

### DIFF
--- a/pkgs-test.py
+++ b/pkgs-test.py
@@ -12,6 +12,7 @@ from datetime import datetime
 import re
 from HTMLTable import HTMLTable
 import html
+import logging
 
 class PackagesIndex:
     def __init__(self, packages_path):


### PR DESCRIPTION
When using your code, I found that the logging.error() was used in pkgs test.py, but the logging module was not referenced