### PR TITLE
Change.get_change_pkg_name(): fix merge unrelated-histories

### DIFF
--- a/pkgs-test.py
+++ b/pkgs-test.py
@@ -126,6 +126,7 @@ class PackagesIndex:
             config_dict = self.dict
         else:
             config_dict = self.__get_config_pkgs(pkgs)
+        print(config_dict)
         return config_dict
 
     def nolatest(self, value=True):
@@ -567,9 +568,10 @@ class Change:
             logging.error(e)
         try:
             os.system(shell + 'git fetch rtt_repo')
-            os.system(shell + 'git merge rtt_repo/{}'.format(self.rtt_branch))
+            os.system(shell + 'git merge rtt_repo/{} --allow-unrelated-histories'.format(self.rtt_branch))
             os.system(shell + 'git reset rtt_repo/{} --soft'.format(self.rtt_branch))
-            os.system(shell + 'git status > git.txt')
+            os.system(shell + 'git status | tee git.txt')
+            os.system(shell + 'git diff --staged | cat')
         except Exception as e:
             logging.error(e)
             return None


### PR DESCRIPTION
当RT-Thread/packages的pr中有force push的时候，
可能会导致git merge时出现`fatal: refusing to merge unrelated histories`。
进而引起检查时有需要检查的版本缺失。

具体情况为，
https://github.com/RT-Thread/packages/pull/1633

解决方法：
git merge添加参数--allow-unrelated-histories。

此外添加了一些日志输出方便排查问题。