### PR TITLE
[Action] Improve the testing of RT-Thread/packages.

### DIFF
--- a/.github/workflows/pkgs-action.yml
+++ b/.github/workflows/pkgs-action.yml
@@ -43,11 +43,21 @@ on:
         default: false
         required: false
         type: boolean
+      package-append-res:
+        description: "Append test res to old res from githubpage."
+        default: false
+        required: false
+        type: boolean
       check-errors:
         description: "Choose whether to check for errors."
         default: true
         required: false
         type: boolean
+      pages-url:
+        description: "Pkgs test res github pages url."
+        default: "https://rt-thread.github.io/packages/"
+        required: false
+        type: string
       deploy-pages:
         description: "Choose whether to deploy pages."
         default: false
@@ -70,7 +80,7 @@ jobs:
         shell: bash 
         run: |
           sudo apt install python3 python3-pip gcc git libncurses5-dev tree -y
-          python3 -m pip install scons==4.4.0 requests tqdm wget dominate PyGithub 
+          python3 -m pip install scons==4.4.0 requests tqdm wget dominate PyGithub requests pytz
       - name: Copy RT-Thread/packages to env
         if: "${{ endsWith(github.repository, '/packages') == true }}"
         shell: bash 
@@ -86,29 +96,27 @@ jobs:
           python pkgs-test.py config --bsps='${{ inputs.bsps }}'
           python pkgs-test.py download
       - name: Carry Out Packages Test
-        if: ${{ inputs.package-test-all == false }}
         shell: bash
         run: |
+          cd ${{ github.workspace }}
+          tree .
           cd ${{ github.workspace }}/pkgs-test
-          if [[ ${{ inputs.package-test-nolatest}} ]]; then
-            echo 'Carry Out Packages Test (nolatest).'
-            python pkgs-test.py --repository='${{ inputs.package-repository }}' --nolatest
+          echo 'Carry Out Packages Test.'
+          if [[ ${{ inputs.package-test-all}} == true ]]; then
+            COMMAND="python pkgs-test.py --pkg=all"
           else
-            echo 'Carry Out Packages Test.'
-            python pkgs-test.py --repository='${{ inputs.package-repository }}'
+            COMMAND="python pkgs-test.py --repository=${{ inputs.package-repository }}"
           fi
-      - name: Carry Out All Packages Test
-        if: ${{ inputs.package-test-all == true }}
-        shell: bash
-        run: |
-          cd ${{ github.workspace }}/pkgs-test
-          if [[ ${{ inputs.package-test-nolatest}} ]]; then
-            echo 'Carry Out All Packages Test (nolatest).'
-            python pkgs-test.py --pkg=all --nolatest
-          else
-            echo 'Carry Out All Packages Test.'
-            python pkgs-test.py --pkg=all
-          fi     
+          if [[ ${{ inputs.package-test-nolatest}} == true ]]; then
+            echo 'nolatest.'
+            COMMAND="$COMMAND --nolatest"
+          fi
+          if [[ ${{ inputs.package-append-res}} == true ]]; then
+            echo 'Append test res to old res from githubpage.'
+            COMMAND="$COMMAND --append_res --pages_url='${{ inputs.pages-url}}'"
+          fi
+          echo "$COMMAND" 
+          eval "$COMMAND"    
       - uses: actions/upload-artifact@v3
         with:
           name: artifacts_export
@@ -131,7 +139,7 @@ jobs:
         shell: bash 
         run: |
           sudo apt install python3 python3-pip -y
-          python3 -m pip install requests tqdm wget dominate PyGithub 
+          python3 -m pip install requests tqdm wget dominate PyGithub requests pytz
       - name: Packages test whether or not error
         shell: bash 
         run: |
@@ -143,7 +151,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: packages-test
-    if: "${{ endsWith(github.repository, '/packages') == true && inputs.deploy-pages }}"
+    if: "${{ inputs.deploy-pages }}"
     steps:
       - name: Download artifacts_export
         uses: actions/download-artifact@v3

--- a/.github/workflows/pkgs-action.yml
+++ b/.github/workflows/pkgs-action.yml
@@ -33,11 +33,16 @@ on:
         default: ${{ github.repository }}
         required: false
         type: string
-      package-version:
-        description: "Packages version to test (separated by spaces)."
-        default: "all"
+      package-test-nolatest:
+        description: "Do not test the latest version of the package."
+        default: false
         required: false
-        type: string
+        type: boolean
+      package-test-all:
+        description: "test the all of the package in RT-Thread/packages."
+        default: false
+        required: false
+        type: boolean
       check-errors:
         description: "Choose whether to check for errors."
         default: true
@@ -54,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          path: repository
       - uses: actions/checkout@v3
         with:
           repository: '${{ inputs.pkgs-test-repository }}'
@@ -63,69 +70,72 @@ jobs:
         shell: bash 
         run: |
           sudo apt install python3 python3-pip gcc git libncurses5-dev tree -y
-          python3 -m pip install scons==4.4.0 requests tqdm wget html-table PyGithub
-      - name: Install Test Resources for package
-        if: "${{ endsWith(github.repository, '/packages') == false }}"
-        shell: bash 
-        run: |
-          cd ${{ github.workspace }}/pkgs-test
-          PYTHONCMD="pkgs_test = __import__('pkgs-test'); \
-                    config = pkgs_test.Config(); \
-                    config.config_rtthread_versions('${{ inputs.rt-thread-versions }}'); \
-                    config.get_resources();"
-          python -c "$PYTHONCMD"
-      - name: Install Test Resources for RT-Thread/packages
+          python3 -m pip install scons==4.4.0 requests tqdm wget dominate PyGithub 
+      - name: Copy RT-Thread/packages to env
         if: "${{ endsWith(github.repository, '/packages') == true }}"
         shell: bash 
         run: |
           cd ${{ github.workspace }}
-          cp -r ../packages ../packages_temp; \
-          mkdir -p ./pkgs-test/env; \
-          cp -r ../packages_temp ./pkgs-test/env/packages; \
-          cd pkgs-test
-          tree
-          PYTHONCMD="pkgs_test = __import__('pkgs-test'); \
-                    config = pkgs_test.Config(); \
-                    config.config_rtthread_versions('${{ inputs.rt-thread-versions }}'); \
-                    config.get_resources();"
-          python -c "$PYTHONCMD"
-      - name: Carry Out Packages Test
+          mkdir -p ./pkgs-test/env
+          cp -r ./repository ./pkgs-test/env/packages
+      - name: Install Test Resources
         shell: bash
         run: |
           cd ${{ github.workspace }}/pkgs-test
-          PYTHONCMD="import os; \
-                      pkgs_test = __import__('pkgs-test'); \
-                      config = pkgs_test.Config(); \
-                      config.config_rtthread_versions('${{ inputs.rt-thread-versions }}'); \
-                      config.action_config_bsps(\"${{ inputs.bsps }}\"); \
-                      packages_index = pkgs_test.PackagesIndex(os.path.join(config.get_path('env'),'packages/packages')); \
-                      pkgs_config_dict = packages_index.repository_seek('${{ inputs.package-repository }}','${{ inputs.package-version }}'); \
-                      logs = pkgs_test.Logs('artifacts_export', config.get_config_data(), pkgs_config_dict); \
-                      build = pkgs_test.Build(config, pkgs_config_dict, logs); \
-                      build.all();"
-          python -c "$PYTHONCMD"
+          python pkgs-test.py config --rtthread='${{ inputs.rt-thread-versions }}'
+          python pkgs-test.py config --bsps='${{ inputs.bsps }}'
+          python pkgs-test.py download
+      - name: Carry Out Packages Test
+        if: ${{ inputs.package-test-all == false }}
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/pkgs-test
+          if [[ ${{ inputs.package-test-nolatest}} ]]; then
+            echo 'Carry Out Packages Test (nolatest).'
+            python pkgs-test.py --repository='${{ inputs.package-repository }}' --nolatest
+          else
+            echo 'Carry Out Packages Test.'
+            python pkgs-test.py --repository='${{ inputs.package-repository }}'
+          fi
+      - name: Carry Out All Packages Test
+        if: ${{ inputs.package-test-all == true }}
+        shell: bash
+        run: |
+          cd ${{ github.workspace }}/pkgs-test
+          if [[ ${{ inputs.package-test-nolatest}} ]]; then
+            echo 'Carry Out All Packages Test (nolatest).'
+            python pkgs-test.py --pkg=all --nolatest
+          else
+            echo 'Carry Out All Packages Test.'
+            python pkgs-test.py --pkg=all
+          fi     
       - uses: actions/upload-artifact@v3
         with:
           name: artifacts_export
           path: ${{ github.workspace }}/pkgs-test/artifacts_export
-      
+
   check-errors:
     runs-on: ubuntu-latest
     needs: packages-test
     if: "${{ inputs.check-errors }}"
     steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: '${{ inputs.pkgs-test-repository }}'
+          ref: '${{ inputs.pkgs-test-branch }}'      
       - name: Download artifacts_export
         uses: actions/download-artifact@v3
         with:
           name: artifacts_export
+      - name: Install Tools
+        shell: bash 
+        run: |
+          sudo apt install python3 python3-pip -y
+          python3 -m pip install requests tqdm wget dominate PyGithub 
       - name: Packages test whether or not error
         shell: bash 
         run: |
-          if [ -f "index.html" ]; then str1=`cat index.html`; else str1=""; fi
-          echo $str1
-          str2="#f00"
-          if [[ $str1 == *$str2* ]]; then echo "Software package test failed." && exit 1;\
-          else echo "Software package test success.";fi
+          python pkgs-test.py check --file='pkgs_res.json'
 
   Deploy-Pages:
     environment:

--- a/README.md
+++ b/README.md
@@ -4,16 +4,44 @@
 
 ### 用法
 
-```
+``` yml
 jobs:
   pkgs-test:
     uses: RT-Thread/pkgs-test/.github/workflows/pkgs-action.yml@main
     with:
       # 指定测试的rt-thread内核版本 使用空格分隔
       # branch "branch:[branch]" tag "tag:[tag]"
-      # e.g. "branch:master tag:v4.1.1"
       # 默认值为 "branch:master tag:v4.1.1"
       rt-thread-versions: "branch:master tag:v4.1.1"
+
+      # 指定测试的bsp 使用空格分隔
+      # [bsp]:[toolchain]
+      # 默认值为 "qemu-vexpress-a9:sourcery-arm stm32/stm32h750-artpi:sourcery-arm k210:sourcery-riscv-none-embed"
+      bsps: "qemu-vexpress-a9:sourcery-arm stm32/stm32h750-artpi:sourcery-arm k210:sourcery-riscv-none-embed"
+      
+      # 测试package时是否测试latest版本，false时测试latest版本。
+      # 默认值为 false
+      package-test-nolatest: false
+      
+      # 测试全部的package，true为测试全部。
+      # 默认值为 false
+      package-test-all: false
+
+      # 是否执行check-errors，true为检查。
+      # 默认值为 true
+      check-errors: true
+
+      # 是否从githubpages下载旧的测试结果，并将新的测试结果与其合并，true为下载并合并。
+      # 默认值为 false
+      package-append-res: false
+
+      # 旧测试结果的githubpages地址。
+      # 默认值为 https://rt-thread.github.io/packages/
+      pages-url: https://rt-thread.github.io/packages/
+
+      # 是否将测试结果发布到githubpages，true是发布。
+      # 默认值为 false
+      deploy-pages: false
 ```
 
 ## 本地使用

--- a/pkgs-test.py
+++ b/pkgs-test.py
@@ -11,8 +11,6 @@ import wget
 from datetime import datetime
 import re
 import pytz
-# from HTMLTable import HTMLTable
-# import html
 from dominate.tags import div, head, style, html, body, p, tr, th, table, td, a, h1, h2, h3
 
 

--- a/pkgs-test.py
+++ b/pkgs-test.py
@@ -126,6 +126,7 @@ class PackagesIndex:
             config_dict = self.dict
         else:
             config_dict = self.__get_config_pkgs(pkgs)
+        print(config_dict)
         return config_dict
 
     def nolatest(self, value=True):
@@ -567,9 +568,10 @@ class Change:
             logging.error(e)
         try:
             os.system(shell + 'git fetch rtt_repo')
-            os.system(shell + 'git merge rtt_repo/{}'.format(self.rtt_branch))
+            os.system(shell + 'git merge rtt_repo/{} --allow-unrelated-histories'.format(self.rtt_branch))
             os.system(shell + 'git reset rtt_repo/{} --soft'.format(self.rtt_branch))
-            os.system(shell + 'git status > git.txt')
+            os.system(shell + 'git status | tee git.txt')
+            os.system(shell + 'git diff --staged | cat')
         except Exception as e:
             logging.error(e)
             return None


### PR DESCRIPTION
- 对packages仓库测试的完善。

> 可以定时检查全部软件包。

> 检查完毕后可以将检查结果推送到github pages。

> 发布页面时可以从githubpage下载旧的测试结果，可以将新的结果与其合并，重新生成新的结果。

- 修改了运行方式，从运行python代码改为执行pkgs-test.py并添加参数。

- 修改了结果的html页面。

> 更改了页面的生成方式，先生成json然后再生成html，方便合并结果。

> 对html页面增加了一些信息，包括最后一次更新的时间，每个版本有多少个软件包通过了测试。

- 修改了check-errors方式。

> 读取json。

