### PR TITLE
[Action]Fix RT-Thread/packages path.

### DIFF
--- a/.github/workflows/pkgs-action.yml
+++ b/.github/workflows/pkgs-action.yml
@@ -86,8 +86,8 @@ jobs:
         shell: bash 
         run: |
           cd ${{ github.workspace }}
-          mkdir -p ./pkgs-test/env
-          cp -r ./repository ./pkgs-test/env/packages
+          mkdir -p ./pkgs-test/env/packages
+          cp -r ./repository ./pkgs-test/env/packages/packages
       - name: Install Test Resources
         shell: bash
         run: |


### PR DESCRIPTION
问题：packages仓库发生改变时，并没有对软件包执行测试。
https://github.com/RT-Thread/packages/actions/runs/5562637568/jobs/10161073435

分析：
根据程序的功能模块划分，定位出现问题的部分应该在`Change.get_change_pkg_name()`。

当输出改变的目录文件目录时，即运行`print(pattern.findall(file_lines))`。

输出：
``` shell
['../peripherals/sensors/', '../peripherals/sensors/sht4x/', '../peripherals/sensors/sht4x/', '../']
```
根据package.json文件目录的获取方式，`package_path = os.path.join(self.packages_path, path, 'package.json')`。

正确的改变的目录文件目录应该是
``` shell
['peripherals/sensors/', 'peripherals/sensors/sht4x/', 'peripherals/sensors/sht4x/']
```

因此判断可能是RT-Thread/packages的目录有问题。

发现action文件里面保存RT-Thread/packages的目录少了一个packages。

```
pkgs-test/env/packages -> pkgs-test/env/packages/packages。
```
