### PR TITLE
[Log]Add single test res json.

### DIFF
--- a/.github/workflows/pkgs-action.yml
+++ b/.github/workflows/pkgs-action.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Packages test whether or not error
         shell: bash 
         run: |
-          python pkgs-test.py check --file='pkgs_res.json'
+          python pkgs-test.py check --file='pkgs_res_single.json'
 
   Deploy-Pages:
     environment:

--- a/pkgs-test.py
+++ b/pkgs-test.py
@@ -309,7 +309,7 @@ class Logs:
             shutil.rmtree(self.logs_path)
         os.makedirs(self.logs_path)
 
-    def __build_res(self):
+    def __build_res(self, append_res=False):
         def download_old_res():
             res_old_url = self.pages_url + 'pkgs_res.json'
             try:
@@ -367,7 +367,7 @@ class Logs:
                 pkg_res['error'] = False
             return pkg_res
 
-        if self.append_res:
+        if append_res:
             pkgs_res_dict = download_old_res()
         else:
             pkgs_res_dict = {}
@@ -515,7 +515,11 @@ class Logs:
         self.master_is_tab = tab
 
     def logs(self):
-        self.pkgs_res_dict = self.__build_res()
+        pkgs_res_single_dict = self.__build_res(False)
+        with open(os.path.join(self.logs_path, 'pkgs_res_single.json'), 'w') as f:
+            json.dump(pkgs_res_single_dict, f)
+
+        self.pkgs_res_dict = self.__build_res(self.append_res)
         with open(os.path.join(self.logs_path, 'pkgs_res.json'), 'w') as f:
             json.dump(self.pkgs_res_dict, f)
 


### PR DESCRIPTION
当软件包在测试的时候，分为几种情况：
1. 软件包索引有更改时对改动的软件包进行测试，或在软件包仓库里面测试，这种情况需要调用check-error来检查是否能通过测试。
3. 定时测试全部的软件包，这种情况不需要调用 check-error。

目前的问题是：

1. 首先定时测试全部的软件包会生成一份全部软件包的json。
2. 当有部分软件包有更改发生更改的时候会将测试结果追加到旧的json上面。
3. 此时的json里面包含了全部软件包的结果，这时执行check-error的话**会对没有必要的结果进行检测**。

因此需要保存两份json，分别是本次测试的结果和追加后的结果（如果设置不追加的话那么两个json文件相同），这样可以当check-error的时候仅对本次测试的部分检查。

