### PR TITLE
Change json structure and html report pages.

### DIFF
--- a/components/logs.py
+++ b/components/logs.py
@@ -202,7 +202,7 @@ class Logs:
             for key in sorted_keys:
                 category_dict[key].sort()
                 sorted_category_dict[key] = category_dict[key]
-                return sorted_category_dict
+            return sorted_category_dict
 
         def get_pkgs_availability_level_dict():
             dict = {0: [], 1: [], 2: []}

--- a/components/logs.py
+++ b/components/logs.py
@@ -5,9 +5,8 @@ import pytz
 import shutil
 import requests
 from datetime import datetime
-from dominate.tags import (div, head, style, html, body,
-                           p, tr, th, table, td, a, h1,
-                           h2, h3, details, summary)
+from dominate.tags import (div, head, style, html, body, details, summary,
+                           p, a, h1, h2, script, ul, li, span,)
 
 
 class Logs:
@@ -21,6 +20,8 @@ class Logs:
         self.append_res = False
         self.pages_url = 'http://rt-thread.github.io/packages/'
         self.pkg_res_version = 'v0.2.0'
+        self.category_dict = {}
+        self.pkgs_availability_level_dict = {}
 
     def __clear_logs_path(self):
         if os.path.isdir(self.logs_path):
@@ -63,7 +64,7 @@ class Logs:
             res['pkg'] = pkg['name']
             res['repository'] = pkg['repository']
             res['versions'] = {}
-
+            res['category'] = pkg['category']
             pkg_res = res['versions']
             version_list = []
             for pkg_version in pkg['pkg']:
@@ -71,63 +72,66 @@ class Logs:
 
             for version in version_list:
                 version_res = {}
+                version_res['rtt_res'] = {}
                 for rtt in rtt_list:
                     rtt_res = {}
+                    rtt_res['bsp_res'] = {}
                     for bsp in bsp_list:
                         bsp_res = {}
                         log_file = get_log_file(
                             version, rtt, bsp, pkg['name'])
                         bsp_res['log_file'] = log_file
                         bsp_res['res'] = check_logfile(log_file)
-                        rtt_res[bsp] = bsp_res
-                    version_res[rtt] = rtt_res
+                        rtt_res['bsp_res'][bsp] = bsp_res
+                    version_res['rtt_res'][rtt] = rtt_res
                 pkg_res[version] = version_res
 
-            pkg_err_level = 0
+            pkg_availability_level = 0
             level_num = [0, 0, 0]
             for version in version_list:
                 version_res = pkg_res[version]
-                version_err_level = 0
+                version_availability_level = 0
                 rtt_err_num = 0
                 for rtt in rtt_list:
-                    rtt_res = version_res[rtt]
+                    rtt_res = version_res['rtt_res'][rtt]
                     bsp_err_num = 0
-                    rtt_err_level = 0
+                    rtt_availability_level = 0
                     for bsp in bsp_list:
-                        bsp_res = rtt_res[bsp]
+                        bsp_res = rtt_res['bsp_res'][bsp]
                         if bsp_res['res'] == 'Failure':
                             bsp_err_num = bsp_err_num + 1
                     if bsp_err_num == 0:
-                        rtt_err_level = 0  # all bsps pass
-                    elif bsp_err_num == len(bsp_list):
-                        rtt_err_level = 1  # part of bsps pass
+                        rtt_availability_level = 0  # all bsps pass
+                    elif bsp_err_num < len(bsp_list):
+                        rtt_availability_level = 1  # part of bsps pass
                         rtt_err_num = rtt_err_num + 1
                     else:
-                        rtt_err_level = 2  # none bsp pass
+                        rtt_availability_level = 2  # none bsp pass
                         rtt_err_num = rtt_err_num + 1
-                    rtt_res['rtt_err_level'] = rtt_err_level
+                    rtt_res['rtt_availability_level'] = rtt_availability_level
                 if rtt_err_num == 0:
-                    version_err_level = 0  # all rtt pass
+                    version_availability_level = 0  # all rtt pass
                     level_num[0] = level_num[0] + 1
                 elif ('master' in version_res and
-                      version_res['master']['rtt_err_level'] == 0):
-                    version_err_level = 1  # master pass
+                      version_res['master']['rtt_availability_level'] == 0):
+                    version_availability_level = 1  # master pass
                     level_num[1] = level_num[1] + 1
                 else:
-                    version_err_level = 2  # master not pass
+                    version_availability_level = 2  # master not pass
                     level_num[2] = level_num[2] + 1
-                version_res['version_err_level'] = version_err_level
+                version_res['version_availability_level'] = \
+                    version_availability_level
 
             if level_num[0] == len(version_list):
-                pkg_err_level = 0  # all version pass
+                pkg_availability_level = 0  # all version pass
             elif (level_num[0] + level_num[1] == len(version_list) or
                   ('latest' in version_list and (
-                      pkg_res['latest']['version_err_level'] == 0 or
-                      pkg_res['latest']['version_err_level'] == 1))):
-                pkg_err_level = 1  # master latest pass
+                      pkg_res['latest']['version_availability_level'] == 0 or
+                      pkg_res['latest']['version_availability_level'] == 1))):
+                pkg_availability_level = 1  # master latest pass
             else:
-                pkg_err_level = 2  # master or latest not pass
-            res['pkg_err_level'] = pkg_err_level
+                pkg_availability_level = 2  # master or latest not pass
+            res['pkg_availability_level'] = pkg_availability_level
             return res
 
         if append_res:
@@ -140,7 +144,6 @@ class Logs:
         else:
             pkgs_res = {}
         pkgs_res['version'] = self.pkg_res_version
-        print(pkgs_res)
         if 'pkgs_res' not in pkgs_res:
             pkgs_res['pkgs_res'] = {}
 
@@ -150,7 +153,6 @@ class Logs:
         bsp_list = []
         for bsp in self.config_data['bsps']:
             bsp_list.append(bsp['name'])
-
         for pkg in self.pkgs_index:
             pkgs_res['pkgs_res'][pkg['name']] = \
                 get_pkg_res(pkg, rtt_list, bsp_list)
@@ -163,127 +165,199 @@ class Logs:
 
     def __html_report(self):
         style_applied = '''
-            body{
-                font-family: verdana,arial,sans-serif;
-                font-size:11px;
+            .hidden { display: none; }
+            .expandable::before {
+                content: '➔';
+                display: inline-block;
+                transform: rotate(0deg);
+                transition: transform 0.3s;
             }
-            table.gridtable {
-                color: #333333;
-                border-width: 1px;
-                border-color: #666666;
-                border-collapse: collapse;
-                font-size:11px;
+            .expanded::before {
+                transform: rotate(90deg);
             }
-            table.gridtable th {
-                border-width: 1px;
-                padding: 8px;
-                border-style: solid;
-                border-color: #666666;
-                background-color: #DDEBF7;
-            }
-            table.gridtable td {
-                border-width: 1px;
-                padding: 8px;
-                border-style: solid;
-                border-color: #666666;
-                background-color: #eeeeee;
-                text-align:center;
-            }
-            table.gridtable td.failed {
-                color: red;
-            }
-            table.gridtable td.successed {
-                color: green;
-            }
-            table.gridtable td.warning {
-                color: yellow;
-            }
-            table.gridtable th.error {
-                background-color: red;
-            }
-            li {
-                margin-top: 5px;
-            }
-            div{
-                margin-top: 10px;
+        '''
+        script_applied = '''
+            function toggleVisibility(id, trigger) {
+                const element = document.getElementById(id);
+                if (element.classList.contains('hidden')) {
+                    element.classList.remove('hidden');
+                    trigger.classList.add('expanded');
+                } else {
+                    element.classList.add('hidden');
+                    trigger.classList.remove('expanded');
+                }
             }
         '''
 
-        def generate_pkg_result_table(pkg):
-            pkg_result_table = table(cls='gridtable')
-            link_pkg = a(pkg['pkg'], href=pkg['repository'])
-            if pkg['error']:
-                pkg_result_table.add(th(link_pkg, colspan='2', cls='error'))
-            else:
-                pkg_result_table.add(th(link_pkg, colspan='2'))
-            for version in pkg['versions']:
-                pkg_version_tr = tr()
-                pkg_version_tr += td(version['version'])
-                if version['res'] == 'Success':
-                    pkg_version_tr += \
-                        td(a(version['res'], href=version['log_file']),
-                           cls='successed')
-                elif version['res'] == 'Failure':
-                    pkg_version_tr += \
-                        td(a(version['res'], href=version['log_file']),
-                           cls='failed')
-                else:
-                    pkg_version_tr += \
-                        td(a(version['res'], href=version['log_file']),
-                           cls='warning')
-                pkg_result_table.add(pkg_version_tr)
-            return pkg_result_table
+        def get_category_dict():
+            category_dict = {}
+            for __, pkg_res in self.pkgs_res['pkgs_res'].items():
+                pkg = pkg_res['pkg']
+                category = pkg_res['category']
+                if category not in category_dict:
+                    category_dict[category] = []
+                category_dict[category].append(pkg)
+            sorted_keys = sorted(category_dict.keys())
+            sorted_category_dict = {}
+            for key in sorted_keys:
+                category_dict[key].sort()
+                sorted_category_dict[key] = category_dict[key]
+                return sorted_category_dict
 
-        def get_success_pkg_num(pkgs):
-            success_pkg_num = 0
-            for __, pkg_res in pkgs.items():
-                for version in pkg_res['versions']:
-                    if version['version'] == 'latest' and \
-                            version['res'] == 'Success':
-                        success_pkg_num = success_pkg_num + 1
-            return success_pkg_num
+        def get_pkgs_availability_level_dict():
+            dict = {0: [], 1: [], 2: []}
+            for pkg, pkg_res in self.pkgs_res['pkgs_res'].items():
+                dict[pkg_res['pkg_availability_level']].append(pkg)
+            return dict
 
-        def generate_result_table():
-            result_div = div(id='pkgs_test_result')
-            result_div.add(h1('Packages Test Result'))
-            result_div.add(
-                p('Last run at: ' + self.pkgs_res['last_run_time']))
-            for rtthread_name, rtthread_res in \
-                    self.pkgs_res['pkgs_res'].items():
-                result_div = div(id='pkgs_test_result_' + rtthread_name)
-                result_div.add(
-                    h2('RT-Thread Version: ' + rtthread_name))
-                for bsp_name, bsp_res in rtthread_res.items():
-                    result_div.add(h3("bsp: {bsp}".format(bsp=bsp_name)))
-                    pkgs_num = len(bsp_res)
-                    success_num = get_success_pkg_num(bsp_res)
-                    result_div.add(
-                        p(f'{pkgs_num} packages in total, ' +
-                          f'{success_num} packages pass the test. ' +
-                          f'({success_num}/{pkgs_num})'))
-                    d = details()
-                    d.add(summary("problem packages: "))
-                    for pkg_name, pkg_res in bsp_res.items():
-                        for version in pkg_res['versions']:
-                            if version['version'] == 'latest' and \
-                                    version['res'] != 'Success':
-                                d.add(
-                                    p(a(pkg_name, href=pkg_res['repository'])))
-                    result_div.add(d)
+        def get_bsp_li(bsp, bsp_res):
+            title = bsp
+            if bsp_res['res'] == 'Failure':
+                title = '🔴 ' + title
+            elif bsp_res['res'] == 'Success':
+                title = '🟢 ' + title
+            elif bsp_res['res'] == 'Invalid':
+                title = '⚪ ' + title
+            bsp_li = li(a(title, href=bsp_res['log_file']))
+            return bsp_li
 
-                rtthread_result_table = table(cls='gridtable')
-                for bsp_name, bsp_res in rtthread_res.items():
-                    bsp_tr = tr()
-                    bsp_tr += td(bsp_name)
-                    for pkg_name, pkg_res in bsp_res.items():
-                        bsp_tr += td(generate_pkg_result_table(pkg_res))
-                    rtthread_result_table.add(bsp_tr)
+        def get_rtt_li(pkg, ver, rtt, rtt_res):
+            title = rtt
+            if rtt_res['rtt_availability_level'] == 0:
+                title = '🟢 ' + title
+            elif rtt_res['rtt_availability_level'] == 1:
+                title = '🟠 ' + title
+            elif rtt_res['rtt_availability_level'] == 2:
+                title = '🔴 ' + title
+            rtt_li = li(title)
+            item_id = pkg + '_' + ver + '_' + rtt
+            rtt_li += span(_class='expandable expanded',
+                           onclick=f"toggleVisibility('{item_id}', this)")
+            rtt_ul = ul(id=item_id)
+            for bsp, bsp_res in rtt_res['bsp_res'].items():
+                rtt_ul += get_bsp_li(bsp, bsp_res)
+            rtt_li += rtt_ul
+            return rtt_li
+
+        def get_version_li(pkg, ver, ver_res):
+
+            title = ver
+            if ver_res['version_availability_level'] == 0:
+                title = '🟢 ' + title
+            elif ver_res['version_availability_level'] == 1:
+                title = '🟠 ' + title
+            elif ver_res['version_availability_level'] == 2:
+                title = '🔴 ' + title
+            version_li = li(title)
+            item_id = pkg + '_' + ver
+            version_li += span(_class='expandable expanded',
+                               onclick=f"toggleVisibility('{item_id}', this)")
+            version_ul = ul(_class='expanded', id=item_id)
+
+            for rtt, rtt_res in ver_res['rtt_res'].items():
+                version_ul += get_rtt_li(pkg, ver, rtt, rtt_res)
+
+            version_li += version_ul
+            return version_li
+
+        def generate_doc():
+            doc_div = div(id='pkgs_test_result')
+            doc_div += h1('RT-Thread Packages Test Result')
+            doc_div += p('Last run at: ' + self.pkgs_res['last_run_time'])
+
+            doc_div += h2('Instructions')
+            desc = details()
+            desc += summary("Symbol Description")
+            desc += p("Package availability level:")
+            desc += p("🟢: All versions pass.")
+            desc += p("🟠: Master(RT-Thread) latest(package) pass.")
+            desc += p("🔴: Master(RT-Thread) latest(package) not pass.")
+
+            desc += p("Package Version availability level:")
+            desc += p("🟢: All RT-Thread versions pass.")
+            desc += p("🟠: Master(RT-Thread) pass.")
+            desc += p("🔴: Master(RT-Thread) not pass.")
+
+            desc += p("RT-Thread availability level:")
+            desc += p("🟢: All bsps pass.")
+            desc += p("🟠: Part of bsps pass.")
+            desc += p("🔴: None bsp pass.")
+
+            desc += p("Test result:")
+            desc += p("🟢: Success")
+            desc += p("🔴: Failure")
+            desc += p("⚪: Invalid")
+
+            doc_div += desc
+
+            doc_div += h2('Summary')
+
+            pkgs_num = 0
+            level_num = {}
+            for level, pkg_list in self.pkgs_availability_level_dict.items():
+                level_num[level] = len(pkg_list)
+                pkgs_num += level_num[level]
+            doc_div += p(f"Tested {pkgs_num} packages.")
+            for level, num in level_num.items():
+                d = details()
+                if level == 0:
+                    d += summary(f"🟢: ({num}/{pkgs_num}) All versions pass.")
+                elif level == 1:
+                    d += summary(f"🟠: ({num}/{pkgs_num}) " +
+                                 "Master(RT-Thread) latest(package) pass.")
+                elif level == 2:
+                    d += summary(f"🔴: ({num}/{pkgs_num}) " +
+                                 "Master(RT-Thread) latest(package) not pass.")
+                pkgs_text = ''
+                for pkg in self.pkgs_availability_level_dict[level]:
+                    pkgs_text += pkg
+                    pkgs_text += ', '
+                d += p(pkgs_text)
+                doc_div += d
+
+            doc_div += h2('Detailed test results:')
+            pkgs_ul = ul()
+            pkgs_res = self.pkgs_res['pkgs_res']
+            for category, pkg_list in self.category_dict.items():
+                category_li = li(category)
+                category_li += span(_class='expandable',
+                                    onclick=("toggleVisibility('" +
+                                             category +
+                                             "', this)"))
+                category_ul = ul(_class='hidden', id=category)
+                for pkg in pkg_list:
+                    pkg_res = pkgs_res[pkg]
+                    title = pkg
+                    if pkg_res['pkg_availability_level'] == 0:
+                        title = '🟢 ' + title
+                    elif pkg_res['pkg_availability_level'] == 1:
+                        title = '🟠 ' + title
+                    elif pkg_res['pkg_availability_level'] == 2:
+                        title = '🔴 ' + title
+                    pkg_li = li(a(title, href=pkgs_res[pkg]['repository']))
+                    pkg_li += span(_class='expandable',
+                                   onclick=f"toggleVisibility('{pkg}', this)")
+                    pkg_ul = ul(_class='hidden', id=pkg)
+
+                    for ver, ver_res in pkg_res['versions'].items():
+                        pkg_ul += get_version_li(pkg, ver, ver_res)
+                    pkg_li += pkg_ul
+                    category_ul += pkg_li
+
+                pkgs_ul += category_li
+                category_li += category_ul
+
+            doc_div += pkgs_ul
+            return doc_div
+
+        self.category_dict = get_category_dict()
+        self.pkgs_availability_level_dict = get_pkgs_availability_level_dict()
 
         html_root = html()
-        with html_root.add(head()):
-            style(style_applied, type='text/css')
-        with html_root.add(body()):
-            generate_result_table()
+        html_root += head(style(style_applied, type='text/css'))
+        html_root += body(generate_doc())
+        html_root += script(script_applied)
+
         return html_root.render()
 
     def master_tab(self, tab=True):
@@ -301,11 +375,11 @@ class Logs:
         with open(pkgs_res_path, 'w') as f:
             json.dump(self.pkgs_res, f)
 
-        # logs_html = self.__html_report()
-        # logs_html_path = os.path.join(self.logs_path, 'index.html')
-        # with open(logs_html_path, 'w') as f:
-        #     for log in logs_html:
-        #         f.write(log)
+        logs_html = self.__html_report()
+        logs_html_path = os.path.join(self.logs_path, 'index.html')
+        with open(logs_html_path, 'w') as f:
+            for log in logs_html:
+                f.write(log)
 
     def path(self):
         return self.logs_path

--- a/components/packages_index.py
+++ b/components/packages_index.py
@@ -24,10 +24,18 @@ class PackagesIndex:
             with open(os.path.join(path, 'package.json'), 'rb') as f:
                 data = json.load(f)
             if 'name' in data and 'enable' in data and 'site' in data:
+                start = "/env/packages/packages/"
+                end = '/' + data['name']
+                pattern = re.escape(start) + "(.*?)" + re.escape(end)
+                result = re.search(pattern, path)
+                category = ''
+                if result:
+                    category = result.group(1)
                 dict = {'name': data['name'],
                         'enable': data['enable'],
                         'author': data['author'],
-                        'repository': data['repository']}
+                        'repository': data['repository'],
+                        'category': category}
                 ver_dict = []
                 for ver in data['site']:
                     if not os.access(os.path.join(path, 'Kconfig'), os.R_OK):


### PR DESCRIPTION
# 修改了测试结果json的结构
更改了测试结果的结构，按照软件包->软件包版本->rt-thread版本->bsp版本的结构来分级。
下面是一个例子。
``` json
{
    "version": "v0.2.0",
    "pkgs_res": {
        "[pkg_name]": {
            "pkg": "[pkg_name]",
            "repository": "[repository_url]",
            "versions": {
                "[pkg_version]": {
                    "rtt_res": {
                        "[rtt_version]": {
                            "bsp_res": {
                                "[bsp_name]": {
                                    "log_file": "[log_file_path]",
                                    "res": "Failure"
                                }
                            },
                            "rtt_availability_level": 2
                        }
                    },
                    "version_availability_level": 2
                }
            },
            "category": "misc",
            "pkg_availability_level": 2
        }
    },
    "last_run_time": "2023-09-04 12:52:27 CST+0800"
}
```
另外，由于json被修改了，所以检查结果的也对应更改了，就是check类里面的。

# 修改了测试结果json的页面
同时，也修改了结果报告页面的结构，首先按照软件包的分类对软件包进行了分类，这个分类在json的"category"里面。
根据这个分类，对软件包结果进行分类展示。

这里是一个例子。
<img width="295" alt="image" src="https://github.com/RT-Thread/pkgs-test/assets/34151213/04d66ec4-46a7-40c0-8008-3ec2d542f008">
<img width="288" alt="image" src="https://github.com/RT-Thread/pkgs-test/assets/34151213/a984960f-b9c2-4c4a-95c9-603aa33f5365">

这里是更进一步的展开。
<img width="461" alt="image" src="https://github.com/RT-Thread/pkgs-test/assets/34151213/858b671d-eec2-44ff-b3ee-c948723bdab2">
软件包名称设置了超链接指向仓库地址，测试log设置超链接指向日志地址。

并且根据软件包测试情况进行了分级。
其中除了测试结果（Success、Failure、Invalid），都是通过数字进行分级。
🟢是0，🟠是1，🔴是2。
```
Package availability level:
🟢: All versions pass.
🟠: Master(RT-Thread) latest(package) pass.
🔴: Master(RT-Thread) latest(package) not pass.

Package Version availability level:
🟢: All RT-Thread versions pass.
🟠: Master(RT-Thread) pass.
🔴: Master(RT-Thread) not pass.

RT-Thread availability level:
🟢: All bsps pass.
🟠: Part of bsps pass.
🔴: None bsp pass.

Test result:
🟢: Success
🔴: Failure
⚪: Invalid
```
这个说明也写在了报告html里面。

并且对这个分级也进行了统计。
<img width="466" alt="image" src="https://github.com/RT-Thread/pkgs-test/assets/34151213/cdbf8787-528f-44de-a589-2b0508c52b65">
这个统计展开以后就是具体的软件包。
<img width="458" alt="image" src="https://github.com/RT-Thread/pkgs-test/assets/34151213/1eb68625-64bb-4976-81b8-fb5e1b567e31">

