### PR TITLE
Add qemu check.

### DIFF
--- a/.github/workflows/pkgs-action.yml
+++ b/.github/workflows/pkgs-action.yml
@@ -73,6 +73,11 @@ on:
         default: false
         required: false
         type: boolean
+      qemu-check:
+        description: "Choose whether run qemu check."
+        default: false
+        required: false
+        type: boolean
 jobs:
   packages-test:
     name: ${{ github.repository }}
@@ -89,7 +94,8 @@ jobs:
       - name: Install Tools
         shell: bash 
         run: |
-          sudo apt install python3 python3-pip gcc git libncurses5-dev tree -y
+          sudo apt update -y 
+          sudo apt install python3 python3-pip gcc git libncurses5-dev tree qemu-system-arm -y
           python3 -m pip install scons==4.4.0 requests tqdm wget dominate PyGithub requests pytz psutil
       - name: Copy RT-Thread/packages to env
         if: "${{ endsWith(github.repository, '/packages') == true }}"
@@ -127,6 +133,10 @@ jobs:
           if [[ ${{ inputs.package-append-res}} == true ]]; then
             echo 'Append test res to old res from githubpage.'
             COMMAND="$COMMAND --append_res --pages_url='${{ inputs.pages-url}}'"
+          fi
+          if [[ ${{ inputs.qemu-check}} == true ]]; then
+          echo 'Append test res to old res from githubpage.'
+          COMMAND="$COMMAND --qemu"
           fi
           echo "$COMMAND" 
           eval "$COMMAND"    

--- a/pkgs-test.py
+++ b/pkgs-test.py
@@ -41,11 +41,14 @@ def init_parser():
                         help='Repository name to seek.',
                         default='')
     parser.add_argument('--append_res', action='store_true',
-                        help='Append test tes to old res from githubpage.',
+                        help='Append test res to old res from githubpage.',
                         default=False)
     parser.add_argument('--pages_url', action='store',
                         help='Pkgs test res github pages url.',
                         default='')
+    parser.add_argument('-q', '--qemu', action='store_true',
+                        help='Test qume output.',
+                        default=False)
 
     subparsers = parser.add_subparsers(dest='command')
 
@@ -138,7 +141,7 @@ def test_run(args):
             logs.pages_url = args.pages_url
         logs.append_res = True
 
-    build = Build(config, pkgs_config_dict, logs, args.j)
+    build = Build(config, pkgs_config_dict, logs, args.j, args.qemu)
 
     build.debug(args.debug)
     if args.verify:


### PR DESCRIPTION
添加qemu检查。

1. 在以qemu开头的bsp上运行qemu，并检查输出结果。

2. 默认的目标的输出结果是`msh />`。
通过在软件包仓库的`.github/workflows`目录下面新建一个`qemu.json`，在里面填入想要在qemu里面输入和输出的一些字符串。
指定软件包名字，软件包版本。输入是一个列表，可以实现多行输入，目标结果是一个字符串。
```json
{
    "hello": {
        "latest": {
            "input": [],
            "output": "hello package initialized."
        }
    }
}
```

3. 其中启动qemu的脚本（`qemu-nographic.sh`）里面的bin文件位置是基于脚本文件所在的相对目录的，和pkg-test的目录不一致，通过程序动态修改了bin文件的位置，这个后面如果bsp里面进行了修改，需要添加针对rtt版本的判断。

4. qemu检查通过qemu-check参数启动

6. qemu的输出会追加到编译日志里面，如果编译成功才会进行qemu检查