### PR TITLE
[config] Add touch_env()

### DIFF
--- a/components/config.py
+++ b/components/config.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import json
 import zipfile
 import shutil
@@ -99,10 +100,25 @@ class Config:
         if not os.path.exists(path):
             os.makedirs(path)
 
+    def __touch_env(self):
+        rtt_list = self.config_data['rtthread']
+        rtt_name = ''
+        for rtt in rtt_list:
+            if rtt['name'] == 'master':
+                rtt_name = rtt['name']
+                break
+        if rtt_name == '' and len(rtt_list) > 0:
+            rtt_name = rtt_list[0]['name']
+        if rtt_name != '':
+            sys.path.append(os.path.join(os.getcwd(), 'rtthread', rtt_name))
+            import tools.menuconfig
+            tools.menuconfig.touch_env()
+
     def get_resources(self):
         for resource in self.resources:
             self.__get_resource(resource)
         self.__get_env()
+        self.__touch_env()
 
     def config_pkgs(self, pkgs_str):
         lines = pkgs_str.split("\n")


### PR DESCRIPTION
构建的时候会使用`tools.menuconfig.touch_env()`在用户目录下创建`.env`文件夹，但是由于并行构建多个工程，可能会在这个过程中产生冲突。
解决方法是在所有的构建执行前运行一下 `touch_env()`（具体是下载各种文件之后运行）。
来源：https://github.com/RT-Thread/rt-thread/pull/8111