### PR TITLE
[fixed]can't find menukconfig.py

### DIFF
--- a/components/config.py
+++ b/components/config.py
@@ -111,8 +111,8 @@ class Config:
             rtt_name = rtt_list[0]['name']
         if rtt_name != '':
             sys.path.append(os.path.join(os.getcwd(), 'rtthread', rtt_name))
-            import tools.menukconfig
-            tools.menukconfig.touch_env()
+            import tools.env_helper
+            tools.env_helper.touch_env()
 
     def get_resources(self):
         for resource in self.resources:


### PR DESCRIPTION
由于rtt仓库中，[统一tools中env相关的接口到env_helper.py文件，并同步调整ci](https://github.com/RT-Thread/rt-thread/pull/9185)，将原来的menukconfig.py文件重命名为env_helper.py，需要同步修改pkgs-test，所有ci才能通过